### PR TITLE
(CM-184) Test email alerts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,6 +38,9 @@ jobs:
           BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
           SIGNON_EMAIL: ${{ secrets.SIGNON_EMAIL }}
           SIGNON_PASSWORD: ${{ secrets.SIGNON_PASSWORD }}
+          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
+          EMAIL_ALERT_EMAIL: ${{ secrets.EMAIL_ALERT_EMAIL }}
+          EMAIL_ALERT_PASSWORD: ${{ secrets.EMAIL_ALERT_PASSWORD }}
         run: npx playwright test
       - uses: actions/upload-artifact@v4
         if: always()

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ BASIC_AUTH_USERNAME=<username>
 BASIC_AUTH_PASSWORD=<password>
 SIGNON_EMAIL=<email>
 SIGNON_PASSWORD=<password>
+NOTIFY_API_KEY=<api_key>
+EMAIL_ALERT_EMAIL=<email_alert_email>
+EMAIL_ALERT_PASSWORD<email_alert_password>
 EOF
 ```
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,189 @@
+import { expect, Page, BrowserContext } from "@playwright/test";
+import { waitForUrlToBeAvailable } from "./utils";
+
+export async function createPensionBlock(
+    page,
+    contentBlockPath,
+    rate,
+    title
+) {
+    await page.goto(contentBlockPath);
+    await page.getByRole("button", { name: "Create content block" }).click();
+    await page.getByLabel("Pension").click();
+    await page.getByRole("button", { name: "Save and continue" }).click();
+
+  await page.getByLabel("Title").fill(title);
+
+  const comboBox = await page.getByRole("combobox", {
+    name: "Lead organisation",
+  });
+  await comboBox.click();
+  await comboBox.getByRole("option").nth(2).click();
+
+  await page.getByRole("button", { name: "Save and continue" }).click();
+
+  await page.getByRole("button", { name: "Add a rate" }).click();
+  await page.getByLabel("Title").fill("Some rate");
+  await page.getByLabel("Amount").fill(rate);
+  await page.getByLabel("Frequency").selectOption("a day");
+  await page.getByLabel("Description").fill("Some description");
+  await page.getByRole("button", { name: "Save and continue" }).click();
+
+  await page.getByRole("button", { name: "Save and continue" }).click();
+
+  await page.getByLabel("confirm").check();
+  await page.getByRole("button", { name: "Publish" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Pension created" }),
+  ).toBeVisible();
+}
+
+export async function embedInWhitehallDoc(
+  page,
+  context,
+  contentBlockPath,
+  whitehallPath,
+  title,
+  timestamp,
+  rate,
+) {
+    const documentTitle = `TEST DOCUMENT - ${timestamp}`;
+
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await page.goto(contentBlockPath);
+    await page.getByRole("link", { name: title }).click();
+    await page.getByText("Copy code").click();
+
+    await page.goto(whitehallPath);
+    await page.getByRole("link", { name: "New document" }).click();
+    await page.getByLabel("News article").check();
+    await page.getByRole("button", { name: "Next" }).click();
+
+    await page.locator(".choices__item").first().click();
+    await page.getByRole("option", { name: "News story", exact: true }).click();
+
+    await page.getByLabel("Title (required)").fill(documentTitle);
+    await page.getByLabel("Summary (required)").fill("Some summary");
+    await page.getByLabel("Body (required)").click();
+    await page.getByLabel("Body (required)").press("ControlOrMeta+v");
+
+    await page.getByRole("button", { name: "Save and go to document" }).click();
+    await page.getByRole("link", { name: "Add tags" }).click();
+    await page.locator('[id="taxonomy_tag_form\\[taxons\\]"]').locator("div").first().click();
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await page.getByRole("button", { name: "Force publish" }).click();
+    await page.getByLabel("Reason for force publishing").fill("Some reason");
+    await page.getByRole("button", { name: "Force publish" }).click();
+
+    await page.getByRole("link", { name: documentTitle }).click();
+    const url = await waitForUrlToBeAvailable(
+        page,
+        await page.getByRole("link", { name: "View on website" }).getAttribute("href")
+    );
+
+  await page.goto(url);
+  await expect(page.getByText(rate)).toBeVisible();
+
+  return { url, title: documentTitle };
+}
+
+export async function embedInMainstreamDoc(
+  page,
+  context,
+  contentBlockPath,
+  mainstreamPath,
+  title,
+  timestamp,
+  rate,
+) {
+  const documentTitle = `TEST DOCUMENT - ${timestamp}`;
+  const documentSlug = `test-document-${timestamp}`;
+
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  await page.goto(contentBlockPath);
+  await page.getByRole("link", { name: title }).click();
+  await page.getByText("Copy code").click();
+
+  await page.goto(mainstreamPath);
+  await page.getByRole("link", { name: "Add artefact" }).click();
+
+  await page.getByLabel("Title").fill(documentTitle);
+  await page.getByLabel("Slug").fill(documentSlug);
+  await page.getByLabel("Format").selectOption("answer");
+  await page.getByRole("button", { name: "Save and go to item" }).click();
+
+  await page.getByLabel("Body").click();
+  await page.getByLabel("Body").press("ControlOrMeta+v");
+
+  await page.getByRole("button", { name: "Save" }).click();
+  await page.getByRole("link", { name: "2nd pair of eyes" }).click();
+  await page
+    .locator("input")
+    .filter({ hasText: "Send to 2nd pair of eyes" })
+    .click();
+  await page.getByRole("link", { name: "Skip review" }).click();
+  await page.locator("input").filter({ hasText: "Skip review" }).click();
+  await page.getByRole("link", { name: "Publish", exact: true }).click();
+  await page.locator("input").filter({ hasText: "Send to publish" }).click();
+
+  const url = await waitForUrlToBeAvailable(
+    page,
+    await page
+      .getByRole("link", { name: "View this on the GOV.UK" })
+      .getAttribute("href"),
+  );
+
+  await page.goto(url);
+  await expect(page.getByText(rate)).toBeVisible();
+
+  return { url, title: documentTitle };
+}
+
+export async function verifyListedInLocations(
+  page,
+  contentBlockPath,
+  blockTitle,
+  whitehallTitle,
+  mainstreamTitle,
+) {
+  await page.goto(contentBlockPath);
+  await page.getByRole("link", { name: blockTitle }).click();
+  await expect(page.locator("#host_editions")).toContainText(whitehallTitle);
+  await expect(page.locator("#host_editions")).toContainText(mainstreamTitle);
+}
+
+export async function updateRateAmount(page, contentBlockPath, title, newRate) {
+  await page.goto(contentBlockPath);
+  await page.getByRole("link", { name: title }).click();
+  await page.getByRole("button", { name: "Edit pension" }).click();
+  await page.getByRole("button", { name: "Save and continue" }).click();
+
+  await page
+    .locator('[data-test-id="embedded_some-rate"]')
+    .getByRole("link", { name: "Edit" })
+    .click();
+  await page.getByLabel("Amount").fill(newRate);
+  await page.getByRole("button", { name: "Save and continue" }).click();
+
+  await page.getByRole("button", { name: "Save and continue" }).click();
+  await page.getByRole("button", { name: "Save and continue" }).click();
+  await page.getByRole("button", { name: "Save and continue" }).click();
+
+  await page.getByLabel("No").check();
+  await page.getByRole("button", { name: "Save and continue" }).click();
+  await page.getByLabel("Publish the edit now").check();
+  await page.getByRole("button", { name: "Save and continue" }).click();
+  await page.getByLabel("I confirm that the details").check();
+  await page.getByRole("button", { name: "Publish" }).click();
+}
+
+export async function verifyUpdateVisible(page, url, updatedRate) {
+  await expect(async () => {
+    await page.goto(`${url}?cacheBust=${Date.now()}`);
+    await expect(page.getByText(updatedRate)).toBeVisible();
+  }).toPass();
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,16 +1,51 @@
-import { expect, Page, BrowserContext } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { waitForUrlToBeAvailable } from "./utils";
 
-export async function createPensionBlock(
-    page,
-    contentBlockPath,
-    rate,
-    title
-) {
-    await page.goto(contentBlockPath);
-    await page.getByRole("button", { name: "Create content block" }).click();
-    await page.getByLabel("Pension").click();
-    await page.getByRole("button", { name: "Save and continue" }).click();
+export async function signUpForEmails(page) {
+  await page.goto(
+    `https://${process.env.PUBLISHING_DOMAIN}/business-and-industry`,
+  );
+
+  await page.getByRole("link", { name: "Get emails for this topic" }).click();
+  await page.getByRole("radio", { name: "Business and industry (all" }).check();
+  await page.getByRole("button", { name: "Continue" }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByRole("radio", { name: "Each time we add" }).check();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page
+    .getByRole("textbox", { name: "Enter your email address" })
+    .fill(process.env.EMAIL_ALERT_EMAIL);
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page
+    .getByRole("button", { name: "Sign in to your GOV.UK One" })
+    .click();
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  await page
+    .getByRole("textbox", { name: "Enter your email address to" })
+    .fill(process.env.EMAIL_ALERT_EMAIL);
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page
+    .getByRole("textbox", { name: "Enter your password" })
+    .fill(process.env.EMAIL_ALERT_PASSWORD);
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  // Optionally click on the Confirm button if it's showing. If the user is already signed up
+  // we won't see it
+  if (await page.getByRole("button", { name: "Confirm" }).isVisible()) {
+    await page.getByRole("button", { name: "Confirm" }).click();
+  }
+}
+
+export async function createPensionBlock(page, contentBlockPath, rate, title) {
+  await page.goto(contentBlockPath);
+  await page.getByRole("button", { name: "Create content block" }).click();
+  await page.getByLabel("Pension").click();
+  await page.getByRole("button", { name: "Save and continue" }).click();
 
   await page.getByLabel("Title").fill(title);
 
@@ -48,41 +83,47 @@ export async function embedInWhitehallDoc(
   timestamp,
   rate,
 ) {
-    const documentTitle = `TEST DOCUMENT - ${timestamp}`;
+  const documentTitle = `TEST DOCUMENT: ${timestamp}`;
 
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
-    await page.goto(contentBlockPath);
-    await page.getByRole("link", { name: title }).click();
-    await page.getByText("Copy code").click();
+  await page.goto(contentBlockPath);
+  await page.getByRole("link", { name: title }).click();
+  await page.getByText("Copy code").click();
 
-    await page.goto(whitehallPath);
-    await page.getByRole("link", { name: "New document" }).click();
-    await page.getByLabel("News article").check();
-    await page.getByRole("button", { name: "Next" }).click();
+  await page.goto(whitehallPath);
+  await page.getByRole("link", { name: "New document" }).click();
+  await page.getByLabel("News article").check();
+  await page.getByRole("button", { name: "Next" }).click();
 
-    await page.locator(".choices__item").first().click();
-    await page.getByRole("option", { name: "News story", exact: true }).click();
+  await page.locator(".choices__item").first().click();
+  await page.getByRole("option", { name: "News story", exact: true }).click();
 
-    await page.getByLabel("Title (required)").fill(documentTitle);
-    await page.getByLabel("Summary (required)").fill("Some summary");
-    await page.getByLabel("Body (required)").click();
-    await page.getByLabel("Body (required)").press("ControlOrMeta+v");
+  await page.getByLabel("Title (required)").fill(documentTitle);
+  await page.getByLabel("Summary (required)").fill("Some summary");
+  await page.getByLabel("Body (required)").click();
+  await page.getByLabel("Body (required)").press("ControlOrMeta+v");
 
-    await page.getByRole("button", { name: "Save and go to document" }).click();
-    await page.getByRole("link", { name: "Add tags" }).click();
-    await page.locator('[id="taxonomy_tag_form\\[taxons\\]"]').locator("div").first().click();
-    await page.getByRole("button", { name: "Save" }).click();
+  await page.getByRole("button", { name: "Save and go to document" }).click();
+  await page.getByRole("link", { name: "Add tags" }).click();
+  await page
+    .getByRole("listitem")
+    .filter({ hasText: "Business and industry" })
+    .locator("div")
+    .click();
+  await page.getByRole("button", { name: "Save" }).click();
 
-    await page.getByRole("button", { name: "Force publish" }).click();
-    await page.getByLabel("Reason for force publishing").fill("Some reason");
-    await page.getByRole("button", { name: "Force publish" }).click();
+  await page.getByRole("button", { name: "Force publish" }).click();
+  await page.getByLabel("Reason for force publishing").fill("Some reason");
+  await page.getByRole("button", { name: "Force publish" }).click();
 
-    await page.getByRole("link", { name: documentTitle }).click();
-    const url = await waitForUrlToBeAvailable(
-        page,
-        await page.getByRole("link", { name: "View on website" }).getAttribute("href")
-    );
+  await page.getByRole("link", { name: documentTitle }).click();
+  const url = await waitForUrlToBeAvailable(
+    page,
+    await page
+      .getByRole("link", { name: "View on website" })
+      .getAttribute("href"),
+  );
 
   await page.goto(url);
   await expect(page.getByText(rate)).toBeVisible();

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,0 +1,18 @@
+import { NotifyClient } from "notifications-node-client";
+
+export async function getEmailAlerts(title) {
+  const notifyClient = new NotifyClient(process.env.NOTIFY_API_KEY);
+  const response = await notifyClient.getNotifications(
+    "email",
+    "delivered",
+    null,
+    null,
+  );
+  const notifications = response.data.notifications;
+  return notifications.filter((notification) => {
+    return (
+      notification.email_address === process.env.EMAIL_ALERT_EMAIL &&
+      notification.subject === `Update from GOV.UK for: ${title}`
+    );
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.5.0",
         "eslint": "^9.31.0",
         "globals": "^16.3.0",
+        "notifications-node-client": "^8.2.1",
         "prettier": "^3.6.2"
       }
     },
@@ -325,6 +326,23 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -339,6 +357,25 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -384,6 +421,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -427,6 +476,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
@@ -437,6 +495,74 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -668,6 +794,42 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -681,6 +843,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -708,6 +916,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -715,6 +935,45 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -808,6 +1067,49 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dev": true,
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -845,11 +1147,83 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -874,6 +1248,20 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/notifications-node-client": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-8.2.1.tgz",
+      "integrity": "sha512-wyZh/NbjN8S2uQX18utYtCyC726BBaGeTc4HeUpdhZv5sYKuaQY94N31v9syh8SzVgehyMzW37y08EePmi+k3Q==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.7.2",
+        "jsonwebtoken": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=14.17.3",
+        "npm": ">=6.14.13"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -1008,6 +1396,12 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1024,6 +1418,38 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^24.1.0",
     "eslint": "^9.31.0",
     "globals": "^16.3.0",
+    "notifications-node-client": "^8.2.1",
     "dotenv": "^16.5.0",
     "prettier": "^3.6.2"
   }

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -1,233 +1,81 @@
-import { expect } from "@playwright/test";
 import { test } from "../lib/cachebust-test";
-import { publishingAppUrl, waitForUrlToBeAvailable } from "../lib/utils";
+import { publishingAppUrl } from "../lib/utils";
+import {
+    createPensionBlock,
+    embedInWhitehallDoc,
+    embedInMainstreamDoc,
+    updateRateAmount,
+    verifyListedInLocations,
+    verifyUpdateVisible,
+} from "../lib/helpers";
+import { expect } from "@playwright/test";
 
 test.describe("Content Block Manager", () => {
   test("Can create and embed an object", async ({ page, context }) => {
+    const timestamp = Date.now();
+    const rate = "£122.33";
+    const updatedRate = "£122.99";
+    const title = `E2E TEST PENSION - ${timestamp}`;
+
     const whitehallPath = publishingAppUrl("whitehall-admin");
     const mainstreamPath = publishingAppUrl("publisher");
-
     const contentBlockPath = `${whitehallPath}/content-block-manager/`;
 
-    await test.step("Logging in", async () => {
-      await page.goto(contentBlockPath);
-      await expect(
-        page.getByRole("banner", { text: "Content Block Manager" }),
-      ).toBeVisible();
-    });
-
-    const rate = "£122.33";
-
-    const title = await test.step("Can create an object", async () => {
-      const title = `E2E TEST PENSION - ${new Date().getTime()}`;
-
-      await page.goto(contentBlockPath);
-      await page.getByRole("button", { name: "Create content block" }).click();
-      await page.getByLabel("Pension").click();
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByLabel("Title").fill(title);
-
-      await expect(async () => {
-        const comboBox = await page.getByRole("combobox", {
-          name: "Lead organisation",
+        await test.step("Given I have logged in", async () => {
+            await page.goto(contentBlockPath);
+            await expect(
+                page.getByRole("heading", { name: "Content Block Manager" })
+            ).toBeVisible();
         });
-        await comboBox.click();
 
-        const option = await comboBox.getByRole("option").nth(2);
-        await option.click();
-      }).toPass();
+        await test.step("And I have created an object", async () => {
+            await createPensionBlock(page, contentBlockPath, rate, title);
+        });
 
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByRole("button", { name: "Add a rate" }).click();
-      await page.getByLabel("Title").fill("Some rate");
-      await page.getByLabel("Amount").fill(rate);
-      await page.getByLabel("Frequency").selectOption("a day");
-      await page.getByLabel("Description").fill("Some description");
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByLabel("confirm").check();
-      await page.getByRole("button", { name: "Publish" }).click();
-
-      await expect(
-        page.getByRole("heading", { name: "Pension created" }),
-      ).toBeVisible();
-
-      return title;
-    });
-
-    const { whitehallUrl, whitehallTitle } =
-      await test.step("Can embed an object in Whitehall", async () => {
-        await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-
-        await page.goto(contentBlockPath);
-
-        await page.getByRole("link", { name: title }).click();
-
-        await page.getByText("Copy code").click();
-
-        await page.goto(whitehallPath);
-
-        await page.getByRole("link", { name: "New document" }).click();
-        await page.getByLabel("News article").check();
-        await page.getByRole("button", { name: "Next" }).click();
-
-        await page.locator(".choices__item").first().click();
-        await page
-          .getByRole("option", { name: "News story", exact: true })
-          .click();
-
-        const documentTitle = `TEST DOCUMENT - ${new Date().getTime()}`;
-
-        await page.getByLabel("Title (required)").fill(documentTitle);
-        await page.getByLabel("Summary (required)").fill("Some summary");
-        await page.getByLabel("Body (required)").click();
-        await page.getByLabel("Body (required)").press("ControlOrMeta+v");
-
-        await page
-          .getByRole("button", { name: "Save and go to document" })
-          .click();
-        await page.getByRole("link", { name: "Add tags" }).click();
-        await page
-          .locator('[id="taxonomy_tag_form\\[taxons\\]"]')
-          .getByRole("list")
-          .locator("div")
-          .first()
-          .click();
-        await page.getByRole("button", { name: "Save" }).click();
-
-        await page.getByRole("button", { name: "Force publish" }).click();
-        await page
-          .getByLabel("Reason for force publishing")
-          .fill("Some reason");
-        await page.getByRole("button", { name: "Force publish" }).click();
-
-        await page.getByRole("link", { name: documentTitle }).click();
-        const url = await waitForUrlToBeAvailable(
+    const { url: whitehallUrl, title: whitehallTitle } =
+      await test.step("Then I should be able to embed my object in a Whitehall document", async () => {
+        return await embedInWhitehallDoc(
           page,
-          await page
-            .getByRole("link", { name: "View on website" })
-            .getAttribute("href"),
+          context,
+          contentBlockPath,
+          whitehallPath,
+          title,
+          timestamp,
+          rate,
         );
-
-        await page.goto(url);
-        await expect(page.getByText(rate)).toBeVisible();
-
-        return { whitehallUrl: url, whitehallTitle: documentTitle };
       });
 
-    const { mainstreamUrl, mainstreamTitle } =
-      await test.step("Can embed an object in Mainstream", async () => {
-        await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-
-        await page.goto(contentBlockPath);
-
-        await page.getByRole("link", { name: title }).click();
-
-        await page.getByText("Copy code").click();
-
-        await page.goto(mainstreamPath);
-
-        await page.getByRole("link", { name: "Add artefact" }).click();
-
-        const documentTitle = `TEST DOCUMENT - ${new Date().getTime()}`;
-        const documentSlug = `test-document-${new Date().getTime()}`;
-
-        await page.getByLabel("Title").fill(documentTitle);
-        await page.getByLabel("Slug").fill(documentSlug);
-        await page.getByLabel("Format").selectOption("answer");
-        await page.getByRole("button", { name: "Save and go to item" }).click();
-
-        await page.getByLabel("Body").click();
-        await page.getByLabel("Body").press("ControlOrMeta+v");
-
-        await page.getByRole("button", { name: "Save" }).click();
-        await page.getByRole("link", { name: "2nd pair of eyes" }).click();
-        await page
-          .locator("input")
-          .filter({ hasText: "Send to 2nd pair of eyes" })
-          .click();
-        await page
-          .getByText("Skip to main content Toggle")
-          .press("ControlOrMeta+r");
-        await page.getByRole("link", { name: "Skip review" }).click();
-        await page.locator("input").filter({ hasText: "Skip review" }).click();
-        await page.getByRole("link", { name: "Publish", exact: true }).click();
-        await page
-          .locator("input")
-          .filter({ hasText: "Send to publish" })
-          .click();
-
-        const url = await waitForUrlToBeAvailable(
+    const { url: mainstreamUrl, title: mainstreamTitle } =
+      await test.step("And I should be able to embed my object in a Mainstream document", async () => {
+        return await embedInMainstreamDoc(
           page,
-          await page
-            .getByRole("link", { name: "View this on the GOV.UK" })
-            .getAttribute("href"),
+          context,
+          contentBlockPath,
+          mainstreamPath,
+          title,
+          timestamp,
+          rate,
         );
-
-        await page.goto(url);
-        await expect(page.getByText(rate)).toBeVisible();
-
-        return { mainstreamUrl: url, mainstreamTitle: documentTitle };
       });
 
-    await test.step("Can see pages in list of locations", async () => {
-      await page.goto(contentBlockPath);
-
-      await page.getByRole("link", { name: title }).click();
-
-      await expect(page.locator("#host_editions")).toContainText(
+    await test.step("And I should see my pages in the list of locations", async () => {
+      await verifyListedInLocations(
+        page,
+        contentBlockPath,
+        title,
         whitehallTitle,
-      );
-      await expect(page.locator("#host_editions")).toContainText(
         mainstreamTitle,
       );
     });
 
-    await test.step("Dependent content updates when block content changes", async () => {
-      const updatedRate = "£122.99";
+    await test.step("When I make a change to my block", async () => {
+      await updateRateAmount(page, contentBlockPath, title, updatedRate);
+    });
 
-      await page.goto(contentBlockPath);
-
-      await page.getByRole("link", { name: title }).click();
-
-      await page.getByRole("button", { name: "Edit pension" }).click();
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page
-        .locator('[data-test-id="embedded_some-rate"]')
-        .getByRole("link", { name: "Edit" })
-        .click();
-      await page.getByLabel("Amount").fill(updatedRate);
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByLabel("No").check();
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByLabel("Publish the edit now").check();
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await page.getByLabel("I confirm that the details").check();
-      await page.getByRole("button", { name: "Publish" }).click();
-
-      await expect(async () => {
-        await page.goto(`${whitehallUrl}?cacheBust=${new Date().getTime()}`);
-        await expect(page.getByText(updatedRate)).toBeVisible();
-      }).toPass();
-
-      await expect(async () => {
-        await page.goto(`${mainstreamUrl}?cacheBust=${new Date().getTime()}`);
-        await expect(page.getByText(updatedRate)).toBeVisible();
-      }).toPass();
+        await test.step("Then the changed block should be visible on my pages", async () => {
+            await verifyUpdateVisible(page, whitehallUrl, updatedRate);
+            await verifyUpdateVisible(page, mainstreamUrl, updatedRate);
+        });
     });
   });
 });


### PR DESCRIPTION
This adds some steps to test email alerts are working. We do this by adding a step to sign the Email Alerts user in Integration / Staging (which is the only user who can sign up for emails - see https://docs.publishing.service.gov.uk/repos/email-alert-api/receiving-emails-from-email-alert-api-in-integration-and-staging.html#in-integration) to email alerts for the topic where our test document will be created.

After a change to the block is made, we use the Notify API to check if an email was sent to that email address for that particular page.