### PR TITLE
Update tests to search for blocks

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,22 @@
 import { expect } from "@playwright/test";
 import { waitForUrlToBeAvailable } from "./utils";
 
+export async function goToContentBlockPage(page, contentBlockPath, blockTitle) {
+  await page.goto(contentBlockPath);
+  await page.getByRole("textbox", { name: "Keyword" }).fill(blockTitle);
+  await page.getByRole("button", { name: "View results" }).click();
+  await page.getByRole("link", { name: blockTitle }).click();
+}
+
+export async function copyCodeForContentBlock(
+  page,
+  contentBlockPath,
+  blockTitle,
+) {
+  await goToContentBlockPage(page, contentBlockPath, blockTitle);
+  await page.getByText("Copy code").click();
+}
+
 export async function signUpForEmails(page) {
   await page.goto(
     `https://${process.env.PUBLISHING_DOMAIN}/business-and-industry`,
@@ -89,9 +105,7 @@ export async function embedInWhitehallDoc(
 
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
-  await page.goto(contentBlockPath);
-  await page.getByRole("link", { name: title }).click();
-  await page.getByText("Copy code").click();
+  await copyCodeForContentBlock(page, contentBlockPath, title);
 
   await page.goto(whitehallPath);
   await page.getByRole("link", { name: "New document" }).click();
@@ -147,9 +161,7 @@ export async function embedInMainstreamDoc(
 
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
-  await page.goto(contentBlockPath);
-  await page.getByRole("link", { name: title }).click();
-  await page.getByText("Copy code").click();
+  await copyCodeForContentBlock(page, contentBlockPath, title);
 
   await page.goto(mainstreamPath);
   await page.getByRole("link", { name: "Add artefact" }).click();
@@ -193,15 +205,13 @@ export async function verifyListedInLocations(
   whitehallTitle,
   mainstreamTitle,
 ) {
-  await page.goto(contentBlockPath);
-  await page.getByRole("link", { name: blockTitle }).click();
+  await goToContentBlockPage(page, contentBlockPath, blockTitle);
   await expect(page.locator("#host_editions")).toContainText(whitehallTitle);
   await expect(page.locator("#host_editions")).toContainText(mainstreamTitle);
 }
 
 export async function updateRateAmount(page, contentBlockPath, title, newRate) {
-  await page.goto(contentBlockPath);
-  await page.getByRole("link", { name: title }).click();
+  await goToContentBlockPage(page, contentBlockPath, title);
   await page.getByRole("button", { name: "Edit pension" }).click();
   await page.getByRole("button", { name: "Save and continue" }).click();
 


### PR DESCRIPTION
Sometimes integration gets clogged with blocks, so the block we’re working on isn’t visible on the first page. This updates the tests to search for the title of the block to make the tests more resilient.