### PR TITLE
(CM-907) Run e2es on a schedule

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,6 +3,8 @@ name: Playwright Tests
 on:
   workflow_dispatch: {}
   workflow_call:
+  schedule:
+    - cron: "0 11 * * 1-5"
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ environment variables in the `.env` file to `staging.publishing.service.gov.uk` 
 [GDS VPN](https://docs.publishing.service.gov.uk/manual/get-started.html#8-connect-to-the-gds-vpn) for these tests
 to run correctly.
 
-## Running in Github Actions
+## Running in GitHub Actions
 
-At the moment, the tests are only run on demand - to run them, go to the [Playwright action](https://github.com/alphagov/content-modelling-e2e/actions/workflows/playwright.yml)
-and click "Run workflow".
+These tests are run on a schedule at 11am every weekday. See the [workflow file](.github/workflows/playwright.yml)
+for more details. Any failures will be reported to the #govuk-content-modelling-automations Slack channel.
+
+To run the tests manually, run the following command locally:
+
+```bash
+gh workflow run playwright.yml
+```


### PR DESCRIPTION
This adds a cron schedule for running our e2es to ensure we are regularly alerted of any issues. Ideally we would run this after every deploy, but this could be problematic, so let's try running on a schedule first.