### PR TITLE
Add helpers to regenerate API key secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ kubectl config use-context govuk-integration
 Create a .env file in the root of the project from the shared secrets:
 
 ```bash
-aws secretsmanager get-secret-value --secret-id govuk/content-block-manager/e2e-secrets \
-  | jq '.SecretString' | jq -r 'fromjson | to_entries[] | "\(.key)=\(.value)"'  > .env
+bin/generate-env-file
 ```
 
 ### Run

--- a/README.md
+++ b/README.md
@@ -66,3 +66,45 @@ To run the tests manually, run the following command locally:
 ```bash
 gh workflow run playwright.yml
 ```
+
+## Troubleshooting
+
+You may occasionally see the following error:
+
+```
+    AxiosError: Request failed with status code 403
+
+       at ../lib/notify.js:5
+
+      3 | export async function getEmailAlerts(title) {
+      4 |   const notifyClient = new NotifyClient(process.env.NOTIFY_API_KEY);
+    > 5 |   const response = await notifyClient.getNotifications(
+        |                    ^
+      6 |     "email",
+      7 |     "delivered",
+      8 |     null,
+        at settle (/home/runner/work/content-modelling-e2e/content-modelling-e2e/node_modules/axios/lib/core/settle.js:19:12)
+        at IncomingMessage.handleStreamEnd (/home/runner/work/content-modelling-e2e/content-modelling-e2e/node_modules/axios/lib/adapters/http.js:793:11)
+        at Axios.request (/home/runner/work/content-modelling-e2e/content-modelling-e2e/node_modules/axios/lib/core/Axios.js:45:41)
+        at getEmailAlerts (/home/runner/work/content-modelling-e2e/content-modelling-e2e/lib/notify.js:5:20)
+        at /home/runner/work/content-modelling-e2e/content-modelling-e2e/tests/content-block-manager.spec.js:87:22
+        at /home/runner/work/content-modelling-e2e/content-modelling-e2e/tests/content-block-manager.spec.js:86:5
+```
+
+This means that the Notify API key that we use to check email alerts has been reset. If this happens, first ensure you
+are logged into the integration AWS environment:
+
+```bash
+eval $(gds aws govuk-integration-developer -e --art 8h)
+kubectl config use-context govuk-integration
+```
+
+Then run:
+
+```bash
+bin/update-notify-secret
+```
+
+This will update the `NOTIFY_API_KEY` environment variable in GitHub. Once this is done, you can re-run the tests.
+
+You may also want to run `bin/generate-env-file` manually to ensure that you can run the tests locally.

--- a/bin/generate-env-file
+++ b/bin/generate-env-file
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+printf "Ensure you have credentials in your integration environment before continuing.\n"
+printf "Press enter to continue, or Ctrl-C to abort."
+
+read -r
+
+aws secretsmanager get-secret-value --secret-id govuk/content-block-manager/e2e-secrets \
+  | jq '.SecretString' | jq -r 'fromjson | to_entries[] | "\(.key)=\(.value)"'  > .env
+
+aws secretsmanager get-secret-value --secret-id govuk/email-alert-api/notify \
+  | jq '.SecretString' | jq -r 'fromjson | "NOTIFY_API_KEY=\(.GOVUK_NOTIFY_API_KEY)"' >> .env

--- a/bin/update-notify-secret
+++ b/bin/update-notify-secret
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+printf "Ensure you have credentials in your integration environment before continuing.\n"
+printf "Press enter to continue, or Ctrl-C to abort."
+
+read -r
+
+printf "Fetching Notify API key from AWS Secrets Manager...\n"
+
+NOTIFY_API_KEY=$(aws secretsmanager get-secret-value --secret-id govuk/email-alert-api/notify | jq '.SecretString' | jq -r 'fromjson | .GOVUK_NOTIFY_API_KEY')
+
+printf "Updating GitHub secret...\n"
+
+gh secret set NOTIFY_API_KEY --repo alphagov/content-modelling-e2e --body "$NOTIFY_API_KEY"


### PR DESCRIPTION
Our tests were failing because the Notify API key we use to check an email alert was sent when updating a content block was rotated. This adds some helper scripts to allow us to fetch the key from the secret store and set the new value in GitHub Actions.