### PR TITLE
Make sure shell script updates Dependabot secrets

### DIFF
--- a/bin/update-notify-secret
+++ b/bin/update-notify-secret
@@ -12,3 +12,4 @@ NOTIFY_API_KEY=$(aws secretsmanager get-secret-value --secret-id govuk/email-ale
 printf "Updating GitHub secret...\n"
 
 gh secret set NOTIFY_API_KEY --repo alphagov/content-modelling-e2e --body "$NOTIFY_API_KEY"
+gh secret set NOTIFY_API_KEY --repo alphagov/content-modelling-e2e --body "$NOTIFY_API_KEY" --app dependabot


### PR DESCRIPTION
Dependabot has access to a different set of secrets, so any PRs from Dependabot were failing. This updates the script to update the secrets to also update the Dependabot secrets, so test runs that originate from Dependabot will pass too.