### PR TITLE
Fix e2e tests after recent cleanup

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -221,7 +221,7 @@ export async function updateRateAmount(page, contentBlockPath, title, newRate) {
   await page.getByRole("button", { name: "Save and continue" }).click();
 
   await page
-    .locator('[data-test-id="embedded_some-rate"]')
+    .locator('[data-testid="embedded_some-rate"]')
     .getByRole("link", { name: "Edit" })
     .click();
   await page.getByLabel("Amount").fill(newRate);


### PR DESCRIPTION
I recently updated this data-test-id attribute to be the more idiomatic format `data-testid`. This change just keeps these tests in line with that update.

See here for the related work:
https://github.com/alphagov/govuk-e2e-tests/pull/479 https://github.com/alphagov/content-block-manager/pull/671 https://gov-uk.atlassian.net/browse/CM-958