### PR TITLE
Fix network requests broken by zscaler

### DIFF
--- a/bin/generate-env-file
+++ b/bin/generate-env-file
@@ -10,3 +10,6 @@ aws secretsmanager get-secret-value --secret-id govuk/content-block-manager/e2e-
 
 aws secretsmanager get-secret-value --secret-id govuk/email-alert-api/notify \
   | jq '.SecretString' | jq -r 'fromjson | "NOTIFY_API_KEY=\(.GOVUK_NOTIFY_API_KEY)"' >> .env
+
+# Instructs Node to use system certificate authority to ensure requests succeed when running ZScaler.
+echo "NODE_USE_SYSTEM_CA=1" >> .env


### PR DESCRIPTION
When running these tests on a laptop running ZScaler, these tests were failing when performing network requests with:
```
    Error: apiRequestContext.get: unable to get local issuer certificate
```
Adding NODE_USE_SYSTEM_CA=1 to the .env file seems to fix this, allowing node to trust ZScaler's man-in-the-middle interference.