### PR TITLE
Notify user if gh cli is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,6 @@ bin/update-notify-secret
 ```
 
 This will update the `NOTIFY_API_KEY` environment variable in GitHub. Once this is done, you can re-run the tests.
+Note: this requires the GitHub CLI (`gh`) to be installed to perform the update in GitHub.
 
 You may also want to run `bin/generate-env-file` manually to ensure that you can run the tests locally.

--- a/bin/update-notify-secret
+++ b/bin/update-notify-secret
@@ -11,5 +11,16 @@ NOTIFY_API_KEY=$(aws secretsmanager get-secret-value --secret-id govuk/email-ale
 
 printf "Updating GitHub secret...\n"
 
+if ! command -v gh &> /dev/null
+then
+    printf "\n\e[31m" # red
+    printf "The 'gh' CLI is not installed. This is required to update GitHub automatically.\n"
+    printf "\e[0m" # reset
+    printf "You can install the 'gh' CLI from https://cli.github.com/ and run this script again.\n"
+    printf "Alternatively if you would like to update the secret manually, the Notify API key is:\n"
+    printf "$NOTIFY_API_KEY\n"
+    exit 1
+fi
+
 gh secret set NOTIFY_API_KEY --repo alphagov/content-modelling-e2e --body "$NOTIFY_API_KEY"
 gh secret set NOTIFY_API_KEY --repo alphagov/content-modelling-e2e --body "$NOTIFY_API_KEY" --app dependabot


### PR DESCRIPTION
Tests for the presence of the `gh` program locally and warns the user if it's not already installed.

Also presents the fetched API key to the user so they can use it manually.