### PR TITLE
Temporarily remove the assertion that update notification was sent

### DIFF
--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -96,8 +96,13 @@ test.describe("Content Block Manager", () => {
     });
 
     await test.step("And the subscribed user should have received an email alert", async () => {
-      const emails = await getEmailAlerts(whitehallTitle);
-      expect(emails.length).toBeGreaterThan(0);
+      console.warn(
+        "WARNING: Skipping the Notify verification due to problem with test user acct, see Jira CM-1000",
+      );
+      return true;
+
+      // const emails = await getEmailAlerts(whitehallTitle);
+      // expect(emails.length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
See Jira [CM-1000](https://gov-uk.atlassian.net/browse/CM-1000)

Our E2E test concludes with an assertion that an email notification has been sent to let interested parties know that the document in question has been updated. It works by querying Notify's API to verify that an email was sent to the expected email address with the expected subject (containing the ID of the document which should have been republished following the publication of a new edition of a block which it embeds).

The subject is something like:

> Update from GOV.UK for: TEST DOCUMENT: 1784130862699

This step in our E2E test recently started failing. On investigation it's been brought to our attention that the role-base email account we were using as `EMAIL_ALERT_EMAIL` to subscribe to updates was disabled because role-based email addresses such as this have caused problems in the past and are no longer supported.

NB: Notify will only deliver to email addresses of team members and guests. Therefore they need to be genuine addresses which can receive messages.

For now we temporarily remove this step whilst we decide on the best way to reinstate this important test in the end to end journey.

Options to explore:

- use Notify's "guest" account functionality in some way

- use a real team member's email address

- find a different mechanism for verifying that the interested parties have been notified that the document in question has been republished:

  -  ticket NAV-19004 has been created to capture the idea of extending the response of
    the `GET /subscriber-lists/metrics/*path` on the [email-alert-api's endpoint][]
    to return a timestamp for when the given subscriber list was most recently triggered.

  - we note that the documentation on [Receive emails from Email Alert API in
    Integration and Staging][] notes that if (in integration) Notify is asked
    to send to an address which isn't for a team member or guest, [the details
    of that unsent email are logged][]. This could be of use. See
    [signUpForEmail()][] for how our test subscribes for updates via the form at:
    https://www.integration.publishing.service.gov.uk/email-signup/?link=/business-and-industry
    Note that to sign up for updates in this way, the user must either verify their
    email address or use a OneLogin account.

[Receive emails from Email Alert API in Integration and Staging]: https://docs.publishing.service.gov.uk/repos/email-alert-api/receiving-emails-from-email-alert-api-in-integration-and-staging.html#content

[the details of that unsent email are logged]:
https://github.com/alphagov/email-alert-api/blob/006afa2ee6c35631b83b16519f8af2c6c2ea5c59/app/services/send_email_service/send_pseudo_email.rb#L10-L20

[email-alert-api's endpoint]:
https://docs.publishing.service.gov.uk/repos/email-alert-api/api.html#get-subscriber-listsmetricspath

[signUpForEmail()]:
https://github.com/alphagov/content-modelling-e2e/blob/604a3324e4f11b7e635d717a5bff89935273d351/lib/helpers.js#L20

[CM-1000]: https://gov-uk.atlassian.net/browse/CM-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ